### PR TITLE
Job history review

### DIFF
--- a/src/main/java/com/modzy/sdk/JobClient.java
+++ b/src/main/java/com/modzy/sdk/JobClient.java
@@ -68,17 +68,10 @@ public class JobClient {
 	 */
 	public List<Job> getJobHistory(JobHistorySearchParams searchParams) throws ApiException{
 		WebTarget webTarget = this.restTarget.path("history");
-		ObjectMapper objMapper = new ObjectMapper();		
-		Map<String, String> map = objMapper.convertValue(searchParams, new TypeReference<Map<String,String>>() {} );		
-		for( Entry<String,String> entry : map.entrySet() ) {
-			webTarget = webTarget.queryParam( entry.getKey(), entry.getValue() );					
-		}
-		if( searchParams.getJobIdentifiers() != null ) {
-			try {				
-				webTarget = webTarget.queryParam( "jobIdentifiers", objMapper.writeValueAsString( Arrays.asList( searchParams.getJobIdentifiers() ) ) );
-			} catch (JsonProcessingException jpe) {
-				throw new ApiException(jpe);
-			}
+		ObjectMapper objMapper = new ObjectMapper();
+		Map<String, String> map = objMapper.convertValue(searchParams, new TypeReference<Map<String,String>>() {} );
+		for( Map.Entry<String,String> entry : map.entrySet() ) {
+			webTarget = webTarget.queryParam( entry.getKey(), entry.getValue() );
 		}
 		Builder builder = webTarget.request(MediaType.APPLICATION_JSON);
 		builder.header("Authorization", "ApiKey "+this.apiKey);

--- a/src/main/java/com/modzy/sdk/dto/JobHistorySearchParams.java
+++ b/src/main/java/com/modzy/sdk/dto/JobHistorySearchParams.java
@@ -20,26 +20,25 @@ public class JobHistorySearchParams extends Pagination{
 	
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
 	private Date endDate;
-	
-	@JsonIgnore
-	private String[] jobIdentifiers;
-	
-	private JobStatus status;
+
+	private String model;
+
+	private JobHistorySearchStatus status;
 
 	public JobHistorySearchParams() {
 		super();
-		this.status=JobStatus.ALL;
+		this.status=JobHistorySearchStatus.ALL;
 	}
 	
-	public JobHistorySearchParams(String user, String accessKey, Date startDate, Date endDate,
-			String[] jobIdentifiers, JobStatus status, Integer page, Integer perPage, 
-			String sortBy, String direction) {
+	public JobHistorySearchParams(
+			String user, String accessKey, Date startDate, Date endDate, String model, JobHistorySearchStatus status,
+			Integer page, Integer perPage, String sortBy, String direction) {
 		this();
 		this.user = user;
 		this.accessKey = accessKey;
 		this.startDate = startDate;
 		this.endDate = endDate;
-		this.jobIdentifiers = jobIdentifiers;
+		this.model = model;
 		this.status = status;
 		this.page = page;
 		this.perPage = perPage;
@@ -79,19 +78,15 @@ public class JobHistorySearchParams extends Pagination{
 		this.endDate = endDate;
 	}
 
-	public String[] getJobIdentifiers() {
-		return jobIdentifiers;
-	}
+	public String getModel(){return this.model;}
 
-	public void setJobIdentifiers(String[] jobIdentifiers) {
-		this.jobIdentifiers = jobIdentifiers;
-	}
+	public void setModel(String model){ this.model = model;}
 
-	public JobStatus getStatus() {
+	public JobHistorySearchStatus getStatus() {
 		return status;
 	}
 
-	public void setStatus(JobStatus status) {
+	public void setStatus(JobHistorySearchStatus status) {
 		this.status = status;
 	}
 	

--- a/src/main/java/com/modzy/sdk/dto/JobHistorySearchStatus.java
+++ b/src/main/java/com/modzy/sdk/dto/JobHistorySearchStatus.java
@@ -1,2 +1,7 @@
-package com.modzy.sdk.dto;public class JobHistorySearchStatus {
+package com.modzy.sdk.dto;
+
+public enum JobHistorySearchStatus {
+    ALL,
+    PENDING,
+    TERMINATED
 }

--- a/src/main/java/com/modzy/sdk/dto/JobHistorySearchStatus.java
+++ b/src/main/java/com/modzy/sdk/dto/JobHistorySearchStatus.java
@@ -1,0 +1,2 @@
+package com.modzy.sdk.dto;public class JobHistorySearchStatus {
+}

--- a/src/main/java/com/modzy/sdk/model/JobStatus.java
+++ b/src/main/java/com/modzy/sdk/model/JobStatus.java
@@ -7,5 +7,4 @@ public enum JobStatus {
     TIMEDOUT,
     CANCELED,
     ERROR,
-    ALL,
 }

--- a/src/test/java/com/modzy/sdk/TestJobClient.java
+++ b/src/test/java/com/modzy/sdk/TestJobClient.java
@@ -16,6 +16,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
+import com.modzy.sdk.dto.JobHistorySearchStatus;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,7 +64,7 @@ public class TestJobClient {
 			fail(e.getMessage());
 		}
 		assertNotNull(model);
-		assertNotEquals(model.getVersions(), 0);		
+		assertNotEquals(model.getVersions().size(), 0);
 		ModelVersion modelVersion = null;
 		try {
 			modelVersion = this.modelClient.getModelVersion(model.getIdentifier(), model.getLatestVersion());
@@ -71,8 +72,8 @@ public class TestJobClient {
 			fail(e.getMessage());
 		}
 		assertNotNull(modelVersion);
-		assertNotEquals(modelVersion.getInputs(), 0);
-		assertNotEquals(modelVersion.getOutputs(), 0);
+		assertNotEquals(modelVersion.getInputs().size(), 0);
+		assertNotEquals(modelVersion.getOutputs().size(), 0);
 		//
 		Map<String,String> sourceMap = new HashMap<String,String>();
 		sourceMap.put("input.txt", "Modzy is great!");
@@ -195,8 +196,9 @@ public class TestJobClient {
 	}
 	
 	@Test
-	public void testGetJobHistory() {
+	public void testGetJobHistoryByName() {
 		JobHistorySearchParams searchParams = new JobHistorySearchParams();
+		searchParams.setUser("a");
 		List<Job> jobs = null;
 		try {
 			jobs = this.jobClient.getJobHistory(searchParams);
@@ -204,15 +206,37 @@ public class TestJobClient {
 			fail(e.getMessage());
 		}
 		assertNotNull(jobs);
-		assertNotEquals(jobs.size(), 0);		
+		assertNotEquals(jobs.size(), 0);
+		String userName;
 		for( Job job : jobs ) {
 			this.logger.info( job.toString() );
 			assertNotNull(job.getJobIdentifier() );
 			assertNotNull(job.getStatus());
-			assertNotNull(job.getModel());			
+			assertNotNull(job.getModel());
 		}
-	}		
-	
+	}
+
+	@Test
+	public void testGetJobHistoryByModel() {
+		JobHistorySearchParams searchParams = new JobHistorySearchParams();
+		//Search by model name
+		searchParams.setModel( "Sentiment Analysis" );
+		List<Job> jobs = null;
+		try {
+			jobs = this.jobClient.getJobHistory(searchParams);
+		} catch (ApiException e) {
+			fail(e.getMessage());
+		}
+		assertNotNull(jobs);
+		assertNotEquals(jobs.size(), 0);
+		for( Job job : jobs ) {
+			this.logger.info( job.toString() );
+			assertNotNull(job.getJobIdentifier() );
+			assertNotNull(job.getStatus());
+			assertNotNull(job.getModel());
+		}
+	}
+
 	@Test
 	public void testGetJobHistoryByAccessKey() {
 		JobHistorySearchParams searchParams = new JobHistorySearchParams();		
@@ -269,10 +293,9 @@ public class TestJobClient {
 	}
 
 	@Test
-	public void testGetJobHistoryByJobIdentifier() {
+	public void testGetJobHistoryByStatus() {
 		JobHistorySearchParams searchParams = new JobHistorySearchParams();
-		//Empty array
-		searchParams.setJobIdentifiers( new String[]{""} );
+		searchParams.setStatus(JobHistorySearchStatus.TERMINATED);
 		List<Job> jobs = null;
 		try {
 			jobs = this.jobClient.getJobHistory(searchParams);
@@ -280,44 +303,13 @@ public class TestJobClient {
 			fail(e.getMessage());
 		}
 		assertNotNull(jobs);
-		assertEquals(jobs.size(), 0);
-		//unexisting identifiers
-		searchParams.setJobIdentifiers( new String[]{"A", "B", "C"} );		
-		try {
-			jobs = this.jobClient.getJobHistory(searchParams);
-		} catch (ApiException e) {
-			fail(e.getMessage());
-		}
-		assertNotNull(jobs);
-		assertEquals(jobs.size(), 0);
-		//existing identifiers
-		Model model = new Model();
-		model.setIdentifier("ed542963de");
-		model.setVersion("0.0.27");		
-		//
-		Map<String,String> sourceMap = new HashMap<String,String>();
-		sourceMap.put("input.txt", "Modzy is great!");
-		JobInput<String> jobInput = new JobInputText();
-		jobInput.addSource(sourceMap);
-		Job job = new Job();
-		job.setModel(model);
-		job.setInput(jobInput);
-		try {			
-			job = this.jobClient.submitJob(job);
-			this.logger.info( job.toString() );
-		} catch (ApiException e) {
-			fail(e.getMessage());
-		}
-		assertNotNull(job);		
-		assertNotNull(job.getJobIdentifier());
-		searchParams.setJobIdentifiers( new String[]{job.getJobIdentifier()} );		
-		try {
-			jobs = this.jobClient.getJobHistory(searchParams);
-		} catch (ApiException e) {
-			fail(e.getMessage());
-		}
-		assertNotNull(jobs);
 		assertNotEquals(jobs.size(), 0);
-		
+		String userName;
+		for( Job job : jobs ) {
+			this.logger.info( job.toString() );
+			assertNotNull(job.getJobIdentifier() );
+			assertNotNull(job.getStatus());
+			assertNotNull(job.getModel());
+		}
 	}
 }


### PR DESCRIPTION
## Description

The SDK has some differences with the job-history-service defined [here](https://models.modzy.com/docs/api-reference/jobs/retrieve-job-history) as follows:

- **jobIdentifiers** is no longer supported
- **model** wasn't handled by the sdk

## Related issues

There are no issues reported

## Tests

JobClientTest was updated according to the new params

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
