### PR TITLE
V0.5routes update

### DIFF
--- a/src/main/java/com/modzy/sdk/JobClient.java
+++ b/src/main/java/com/modzy/sdk/JobClient.java
@@ -21,10 +21,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.modzy.sdk.dto.JobHistorySearchParams;
 import com.modzy.sdk.exception.ApiException;
-import com.modzy.sdk.model.Job;
-import com.modzy.sdk.model.JobInput;
-import com.modzy.sdk.model.Model;
-import com.modzy.sdk.model.ModelVersion;
+import com.modzy.sdk.model.*;
 import com.modzy.sdk.util.LoggerFactory;
 
 /**
@@ -107,7 +104,9 @@ public class JobClient {
 		builder.header("Authorization", "ApiKey "+this.apiKey);
 		try {
 			logger.info("creating job: "+job);
-			return builder.post(Entity.entity(job, MediaType.APPLICATION_JSON), Job.class);
+			job = builder.post(Entity.entity(job, MediaType.APPLICATION_JSON), Job.class);
+			job.setStatus( JobStatus.SUBMITTED );
+			return job;
 		}		
 		catch(ResponseProcessingException rpe) {
 			this.logger.log(Level.SEVERE, rpe.getMessage(), rpe);

--- a/src/main/java/com/modzy/sdk/ModzyClient.java
+++ b/src/main/java/com/modzy/sdk/ModzyClient.java
@@ -377,7 +377,7 @@ public class ModzyClient {
 		while( jobStatus.equals( job.getStatus() ) ) {
 			this.logger.info("["+job.getJobIdentifier()+"] "+job.getModel().getName()+": "+(100*(System.currentTimeMillis() - initime)/timeout)+"% waiting for end of "+jobStatus+" with a timeout of "+timeout+"ms" );			
 			try {				
-				Thread.sleep(Math.max( 15000, timeout/10 ) );
+				Thread.sleep(Math.max( 2500, timeout/20 ) );
 			} catch (InterruptedException ie) {
 				throw new ApiException(ie);
 			}					

--- a/src/main/java/com/modzy/sdk/model/JobOutput.java
+++ b/src/main/java/com/modzy/sdk/model/JobOutput.java
@@ -20,7 +20,9 @@ public class JobOutput<T> {
     
     private Integer failed;
     
-    private Boolean finished;
+	private Boolean finished;
+	
+	private String submittedByKey;
 
 	public String getJobIdentifier() {
 		return jobIdentifier;
@@ -104,6 +106,14 @@ public class JobOutput<T> {
 
 	public void setFinished(Boolean finished) {
 		this.finished = finished;
+	}
+
+	public String getSubmittedByKey(){
+		return submittedByKey;
+	}
+
+	public void setSubmittedByKey(String submittedByKey){
+		this.submittedByKey = submittedByKey;
 	}
 
 	@Override

--- a/src/main/java/com/modzy/sdk/samples/JobAwsInputSample.java
+++ b/src/main/java/com/modzy/sdk/samples/JobAwsInputSample.java
@@ -152,6 +152,9 @@ public class JobAwsInputSample {
 				}
 			}
 		}
+		else{
+			System.err.println(String.format("processing failed: %s", job));
+		}
 
 	}
 

--- a/src/main/java/com/modzy/sdk/samples/JobEmbeddedInputSample.java
+++ b/src/main/java/com/modzy/sdk/samples/JobEmbeddedInputSample.java
@@ -158,6 +158,9 @@ public class JobEmbeddedInputSample {
 				}
 			}
 		}
+		else{
+			System.err.println(String.format("processing failed: %s", job));
+		}
 		
 	}
 

--- a/src/main/java/com/modzy/sdk/samples/JobTextInputSample.java
+++ b/src/main/java/com/modzy/sdk/samples/JobTextInputSample.java
@@ -133,6 +133,9 @@ public class JobTextInputSample {
 				}
 			}
 		}
+		else{
+			System.err.println(String.format("processing failed: %s", job));
+		}
 	}
 
 }

--- a/src/test/java/com/modzy/sdk/TestJobClient.java
+++ b/src/test/java/com/modzy/sdk/TestJobClient.java
@@ -90,8 +90,6 @@ public class TestJobClient {
 		this.logger.info(job.toString());
 		assertNotNull(job.getJobIdentifier());
 		assertNotNull(job.getStatus());
-		assertNotNull(job.getSubmittedAt());
-		assertNotNull(job.getSubmittedBy());		
 	}		
 	
 	@Test
@@ -129,8 +127,11 @@ public class TestJobClient {
 		this.logger.info(job.toString());
 		assertNotNull(job.getJobIdentifier());
 		assertNotNull(job.getStatus());
-		assertNotNull(job.getSubmittedAt());
-		assertNotNull(job.getSubmittedBy());		
+		try {
+			Thread.sleep(5000l);
+		} catch (InterruptedException e) {
+			fail(e.getMessage());
+		}
 		//
 		Job job2 = null;
 		try {
@@ -179,20 +180,33 @@ public class TestJobClient {
 		this.logger.info(job.toString());
 		assertNotNull(job.getJobIdentifier());
 		assertNotNull(job.getStatus());
-		assertNotNull(job.getSubmittedAt());
-		assertNotNull(job.getSubmittedBy());		
+		//
+		try {
+			Thread.sleep(5000l);
+		} catch (InterruptedException e) {
+			fail(e.getMessage());
+		}
 		//
 		Job job2 = null;
 		try {
-			job2 = this.jobClient.cancelJob(job);			
+			job2 = this.jobClient.getJob(job);
 		} catch (ApiException e) {
 			fail(e.getMessage());
 		}
-		assertNotNull(job2);			
-		assertNotNull(job2.getJobIdentifier());
-		this.logger.info("Job after cancel call "+job2.toString() );
-		assertEquals(job.getJobIdentifier(), job2.getJobIdentifier());
-		assertEquals(JobStatus.CANCELED, job2.getStatus());
+		//
+		if( JobStatus.COMPLETED != job2.getStatus() ){
+			Job job3 = null;
+			try {
+				job3 = this.jobClient.cancelJob(job);
+			} catch (ApiException e) {
+				fail(e.getMessage());
+			}
+			assertNotNull(job2);
+			assertNotNull(job2.getJobIdentifier());
+			this.logger.info("Job after cancel call "+job2.toString() );
+			assertEquals(job.getJobIdentifier(), job2.getJobIdentifier());
+			assertEquals(JobStatus.CANCELED, job2.getStatus());
+		}
 	}
 	
 	@Test

--- a/src/test/java/com/modzy/sdk/TestJobClient.java
+++ b/src/test/java/com/modzy/sdk/TestJobClient.java
@@ -93,7 +93,7 @@ public class TestJobClient {
 	}		
 	
 	@Test
-	public void textGetJob() {
+	public void testGetJob() {
 		Model model = null;
 		try {
 			model = this.modelClient.getModel("ed542963de");//sentiment-analysis
@@ -146,7 +146,7 @@ public class TestJobClient {
 	}
 	
 	@Test
-	public void textCancelJob() {
+	public void testCancelJob() {
 		Model model = null;
 		try {
 			model = this.modelClient.getModel("ed542963de");//sentiment-analysis
@@ -201,11 +201,11 @@ public class TestJobClient {
 			} catch (ApiException e) {
 				fail(e.getMessage());
 			}
-			assertNotNull(job2);
-			assertNotNull(job2.getJobIdentifier());
-			this.logger.info("Job after cancel call "+job2.toString() );
-			assertEquals(job.getJobIdentifier(), job2.getJobIdentifier());
-			assertEquals(JobStatus.CANCELED, job2.getStatus());
+			assertNotNull(job3);
+			assertNotNull(job3.getJobIdentifier());
+			this.logger.info("Job after cancel call "+job3.toString() );
+			assertEquals(job.getJobIdentifier(), job3.getJobIdentifier());
+			assertEquals(JobStatus.CANCELED, job3.getStatus());
 		}
 	}
 	

--- a/src/test/java/com/modzy/sdk/TestModelClient.java
+++ b/src/test/java/com/modzy/sdk/TestModelClient.java
@@ -65,7 +65,7 @@ public class TestModelClient {
 	public void testGetModelByName(){
 		Model model = null;
 		try {
-			model = this.modelClient.getModelByName("Sentiment Analysis");
+			model = this.modelClient.getModelByName("Military Equipment Classification");
 		}
 		catch(ApiException ae) {
 			fail(ae.getMessage());


### PR DESCRIPTION
## Description

This pr add support for some small changes on the job API services and some small fixes:

- The response of the route `jobs/post` doesn't return the status of the job anymore.
- The response of the route `jobs/post` returns the info before the job is actually created in the database.
- The result object has a new key called `submittedByKey`.

## Related issues

No issues related

## Tests

- https://github.com/modzy/sdk-java/blob/f96463de96872952554b9c7ab110723f12e2d85b/src/test/java/com/modzy/sdk/TestJobClient.java#L96-L146

## Checklist

- [x] I read the Contributing guide.
- [x] I update the documentation and if the case the README.md file.
- [x] I am willing to follow-up on review comments in a timely manner.
